### PR TITLE
Fix for React Native Consumers

### DIFF
--- a/CreditCardEntry/src/com/devmarvel/creditcardentry/internal/CreditCardEntry.java
+++ b/CreditCardEntry/src/com/devmarvel/creditcardentry/internal/CreditCardEntry.java
@@ -556,6 +556,14 @@ public class CreditCardEntry extends HorizontalScrollView implements
         int length = number.length();
         String digits = number.substring(length - 4);
         textFourDigits.setText(digits);
+        relayoutChildren(this);
+    }
+
+    private static void relayoutChildren(View view) {
+        view.measure(
+                View.MeasureSpec.makeMeasureSpec(view.getMeasuredWidth(), View.MeasureSpec.EXACTLY),
+                View.MeasureSpec.makeMeasureSpec(view.getMeasuredHeight(), View.MeasureSpec.EXACTLY));
+        view.layout(view.getLeft(), view.getTop(), view.getRight(), view.getBottom());
     }
 
     private void nextField(CreditEntryFieldBase currentField, String initialFieldValue) {

--- a/CreditCardEntryDemo/res/layout/activity_main.xml
+++ b/CreditCardEntryDemo/res/layout/activity_main.xml
@@ -23,7 +23,6 @@
 
         <com.devmarvel.creditcardentry.library.CreditCardForm
             android:id="@+id/form_no_zip"
-        short_card_number_position
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:padding="15dp"


### PR DESCRIPTION
1. When setting the 4 digits text, the whole layout in RN does not redraw, causing blank content to appear. This happens on most Android 7.0 devices that we tested.
2. This adds a force relayout that mostly fixes the issue. 
3. Removes floating text in example XML
See https://github.com/tipsi/tipsi-stripe/issues/168