### PR TITLE
Move hint texts to string resources

### DIFF
--- a/CreditCardEntry/res/values/strings.xml
+++ b/CreditCardEntry/res/values/strings.xml
@@ -4,5 +4,9 @@
     <string name="ExpirationDateHelp">Expiration date (MM/YY)</string>
     <string name="SecurityCodeHelp">Security code (CVV)</string>
     <string name="ZipHelp">Zip code of billing address</string>
+    <string name="SecurityCodeFieldHint">CVV</string>
+    <string name="ExpDateFieldHint">MM/YY</string>
+    <string name="ZipCodeFieldHint">   ZIP   </string>
+    <string name="CreditCardFormCardNumberHint">1234 5678 9012 3456</string>
 
 </resources>

--- a/CreditCardEntry/src/com/devmarvel/creditcardentry/fields/ExpDateText.java
+++ b/CreditCardEntry/src/com/devmarvel/creditcardentry/fields/ExpDateText.java
@@ -30,7 +30,7 @@ public class ExpDateText extends CreditEntryFieldBase {
 
 	void init() {
 		super.init();
-		setHint("MM/YY");
+		setHint(R.string.ExpDateFieldHint);
 	}
 
 	/* TextWatcher Implementation Methods */

--- a/CreditCardEntry/src/com/devmarvel/creditcardentry/fields/SecurityCodeText.java
+++ b/CreditCardEntry/src/com/devmarvel/creditcardentry/fields/SecurityCodeText.java
@@ -34,7 +34,7 @@ public class SecurityCodeText extends CreditEntryFieldBase {
 
 	void init() {
 		super.init();
-		setHint("CVV");
+		setHint(R.string.SecurityCodeFieldHint);
 	}
 
 	/* TextWatcher Implementation Methods */

--- a/CreditCardEntry/src/com/devmarvel/creditcardentry/fields/ZipCodeText.java
+++ b/CreditCardEntry/src/com/devmarvel/creditcardentry/fields/ZipCodeText.java
@@ -31,7 +31,7 @@ public class ZipCodeText extends CreditEntryFieldBase {
 		super.init();
 		maxChars = 5;
 		setMaxChars(maxChars);
-		setHint("   ZIP   ");
+		setHint(R.string.ZipCodeFieldHint);
 	}
 
 	@Override

--- a/CreditCardEntry/src/com/devmarvel/creditcardentry/library/CreditCardForm.java
+++ b/CreditCardEntry/src/com/devmarvel/creditcardentry/library/CreditCardForm.java
@@ -34,7 +34,7 @@ public class CreditCardForm extends RelativeLayout {
 	private Drawable inputBackground;
 	private boolean useDefaultColors;
 	private boolean animateOnError;
-	private String cardNumberHint = "1234 5678 9012 3456";
+	private String cardNumberHint;
 
 	public CreditCardForm(Context context) {
 		this(context, null);
@@ -76,7 +76,7 @@ public class CreditCardForm extends RelativeLayout {
 			}
 
 			// defaults if not set by user
-			if(cardNumberHint == null) cardNumberHint = "1234 5678 9012 3456";
+			if(cardNumberHint == null) cardNumberHint = context.getResources().getString(R.string.CreditCardFormCardNumberHint);
 			if(inputBackground == null) {
 				//noinspection deprecation
 				inputBackground = context.getResources().getDrawable(R.drawable.background_white);


### PR DESCRIPTION
- Move all hint texts to string resources.
- As now all UI strings are on resource files, these resources can be overrided by main project (which uses this lib).
- This allows us to fully localize the UI.