### PR TITLE
Remove values from id elements

### DIFF
--- a/CreditCardEntry/res/values/ids.xml
+++ b/CreditCardEntry/res/values/ids.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <item name="cc_form_layout" type="id">1111</item>
-    <item name="cc_entry" type="id">1000</item>
-    <item name="cc_entry_internal" type="id">3000</item>
-    <item name="cc_card" type="id">2222</item>
-    <item name="cc_exp" type="id">3333</item>
-    <item name="cc_ccv" type="id">4444</item>
-    <item name="cc_zip" type="id">5555</item>
-    <item name="cc_four_digits" type="id">6666</item>
-    <item name="text_helper" type="id">2000</item>
+    <item name="cc_form_layout" type="id" />
+    <item name="cc_entry" type="id" />
+    <item name="cc_entry_internal" type="id" />
+    <item name="cc_card" type="id" />
+    <item name="cc_exp" type="id" />
+    <item name="cc_ccv" type="id" />
+    <item name="cc_zip" type="id" />
+    <item name="cc_four_digits" type="id" />
+    <item name="text_helper" type="id" />
     <item name="null_color" type="color">234234</item>
 </resources>


### PR DESCRIPTION
Starting with build-tools version 28, aapt2 errors on these with the message `inner element must either be a resource reference or empty`.